### PR TITLE
allow multiple debuggers

### DIFF
--- a/libdebug/__init__.py
+++ b/libdebug/__init__.py
@@ -1,4 +1,4 @@
-from .libdebug import Debugger
+from .libdebug import Debugger, PtraceFail, DebugFail
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging

--- a/libdebug/libdebug.py
+++ b/libdebug/libdebug.py
@@ -358,12 +358,13 @@ class ThreadDebug():
 
 class Debugger:
 
-    def __init__(self, pid=None):
+    def __init__(self, pid=None, multithread=True):
         self.pid = None
         self.threads = {}
         self.cur_tid = None
         self.old_pid = None
         self.process = None
+        self.multithread = multithread
         #According to ptrace manual we need to keep track od the running state to discern if ESRCH is becouse the process is running or dead
         self.running = True
         self.ptrace = Ptracer()
@@ -429,7 +430,10 @@ class Debugger:
         buf = create_string_buffer(100)
         # Ho paura che -1 crei grossi problemi quando vuoi debuggere diversi programmi nello stesso script. Già lo script dei test ha problemi perchè catcha l'exit di processi precedenti. Quando trovo il tempo miglioro questa parte, ma saranno grosse modifiche :(
         logging.debug("waiting...")
-        r = self.ptrace.waitpid(-1, buf, options) 
+        if self.multithread:
+            r = self.ptrace.waitpid(-1, buf, options) 
+        else:
+            r = self.ptrace.waitpid(self.pid, buf, options) 
 
         # In qualche modo evita molti problemi...
         time.sleep(0.02)

--- a/libdebug/libdebug.py
+++ b/libdebug/libdebug.py
@@ -280,6 +280,7 @@ class ThreadDebug():
         self.running = True
         self.stopped.clear()
         self.ptrace.singlestep(self.tid)
+        self.wait()
 
 
     def cont(self):
@@ -377,8 +378,6 @@ class ThreadDebug():
             self.step()
             # send signal to stop the execution as soon as we detach
             self._sig_stop()
-        # I still have to find out why this sleep is needed...
-        time.sleep(0.5)
         self.ptrace.detach(self.tid)
         
 class Debugger:
@@ -825,7 +824,6 @@ class Debugger:
         self.__last_action = "step"
         for tid, t in self.threads.items():
             t.step()
-        self.wait() # Non dovrebbe stare dentro al loop per essere sicuri che si siano fermati tutti i thread ?
 
     def next(self):
         self._enforce_stop()

--- a/libdebug/libdebug.py
+++ b/libdebug/libdebug.py
@@ -283,7 +283,7 @@ class ThreadDebug():
         self.wait()
 
 
-    def cont(self):
+    def cont(self, signal=0x0):
         """
         Continue the execution until the next breakpoint is hitted or the program is stopped
         """
@@ -291,7 +291,7 @@ class ThreadDebug():
         self.stopped.clear()
         # Probably should implement a timeout
         logging.debug("[TID %d] cont", self.tid)
-        self.ptrace.cont(self.tid)
+        self.ptrace.cont(self.tid, signal)
 
     #Struct User
     def _peek_user(self, addr):
@@ -851,7 +851,7 @@ class Debugger:
             if self.rip == rip:
                 break
 
-    def cont(self, blocking=True):
+    def cont(self, blocking=True, signal=0x0):
         """
         Continue the execution until the next breakpoint is hitted or the program is stopped
         """
@@ -866,7 +866,7 @@ class Debugger:
         # while self.running:
         for tid, t in self.threads.items():
             if t.stopped.is_set(): # if not t.running: 
-                t.cont()
+                t.cont(signal=signal)
         if blocking:
             self.wait()
             logging.debug("Continue Stopped")

--- a/libdebug/libdebug.py
+++ b/libdebug/libdebug.py
@@ -271,7 +271,7 @@ class ThreadDebug():
             return False
 
 
-    def step(self):
+    def step(self, signal=0x0):
         """
         Execute the next instruction (Step Into)
         """
@@ -279,7 +279,7 @@ class ThreadDebug():
         logging.debug(f"[TID {self.tid}] Step")
         self.running = True
         self.stopped.clear()
-        self.ptrace.singlestep(self.tid)
+        self.ptrace.singlestep(self.tid, signal=signal)
         self.wait()
 
 
@@ -810,12 +810,12 @@ class Debugger:
                 self.breakpoints[b] = None
 
     # step that won't send a message to the user.
-    def __hidden_step(self):
+    def __hidden_step(self, signal=0x0):
         self.__flag_hidden_step = True
-        self.step()
+        self.step(signal=signal)
 
     #** Non ho capito perchè fai step di tutti i thread e non solo di quello su cui stai lavorando
-    def step(self):
+    def step(self, signal=0x0):
         """
         Execute the next instruction (Step Into)
         """
@@ -823,7 +823,7 @@ class Debugger:
         self.stopped.clear()    
         self.__last_action = "step"
         for tid, t in self.threads.items():
-            t.step()
+            t.step(signal=signal)
 
     def next(self):
         self._enforce_stop()
@@ -857,7 +857,7 @@ class Debugger:
         """
 
         #I need to execute at least another instruction otherwise I get always in the same bp
-        self.__hidden_step()
+        self.__hidden_step(signal=signal)
         self._set_breakpoints()
         self.running = True
         self.stopped.clear()
@@ -866,7 +866,7 @@ class Debugger:
         # while self.running:
         for tid, t in self.threads.items():
             if t.stopped.is_set(): # if not t.running: 
-                t.cont(signal=signal)
+                t.cont()
         if blocking:
             self.wait()
             logging.debug("Continue Stopped")

--- a/libdebug/ptrace.py
+++ b/libdebug/ptrace.py
@@ -162,9 +162,9 @@ class Ptrace():
         return buf
 
 
-    def singlestep(self, tid):
+    def singlestep(self, tid, signal=0x0):
         self.libc.ptrace.argtypes = self.args_int
-        if (self.libc.ptrace(PTRACE_SINGLESTEP, tid, NULL, NULL) == -1):
+        if (self.libc.ptrace(PTRACE_SINGLESTEP, tid, NULL, signal) == -1):
             raise PtraceFail("Step Failed. Do you have permisions? Running as sudo?")
 
 
@@ -301,7 +301,7 @@ class Ptracer:
                         self.retval.put(self.ptrace.getfpregs(tid))
 
                     if ptrace_request == PTRACE_SINGLESTEP:
-                        self.retval.put(self.ptrace.singlestep(tid))
+                        self.retval.put(self.ptrace.singlestep(tid, arg2))
 
                     if ptrace_request == PTRACE_CONT:
                         self.retval.put(self.ptrace.cont(tid, arg2))
@@ -366,8 +366,8 @@ class Ptracer:
 
         @lock_decorator
         @debug_decorator
-        def singlestep(self, tid):
-            self.queries.put((PTRACE_SINGLESTEP, tid, NULL, NULL))
+        def singlestep(self, tid, signal=0x0):
+            self.queries.put((PTRACE_SINGLESTEP, tid, NULL, signal))
             return self.retval.get()
 
         @lock_decorator

--- a/libdebug/ptrace.py
+++ b/libdebug/ptrace.py
@@ -168,9 +168,9 @@ class Ptrace():
             raise PtraceFail("Step Failed. Do you have permisions? Running as sudo?")
 
 
-    def cont(self, tid):
+    def cont(self, tid, signal):
         self.libc.ptrace.argtypes = self.args_int
-        if (self.libc.ptrace(PTRACE_CONT, tid, NULL, NULL) == -1):
+        if (self.libc.ptrace(PTRACE_CONT, tid, NULL, signal) == -1):
             raise PtraceFail("[%d] Continue Failed. Do you have permisions? Running as sudo?" % tid)
 
 
@@ -304,7 +304,7 @@ class Ptracer:
                         self.retval.put(self.ptrace.singlestep(tid))
 
                     if ptrace_request == PTRACE_CONT:
-                        self.retval.put(self.ptrace.cont(tid))
+                        self.retval.put(self.ptrace.cont(tid, arg2))
 
                     if ptrace_request == PTRACE_POKEDATA:
                         self.retval.put(self.ptrace.poke(tid, arg1, arg2))
@@ -372,8 +372,8 @@ class Ptracer:
 
         @lock_decorator
         @debug_decorator
-        def cont(self, tid):
-            self.queries.put((PTRACE_CONT, tid, NULL, NULL))
+        def cont(self, tid, signal=0x0):
+            self.queries.put((PTRACE_CONT, tid, NULL, signal))
             return self.retval.get()
 
         @lock_decorator

--- a/tests/test.py
+++ b/tests/test.py
@@ -57,6 +57,26 @@ class Debugger_read(unittest.TestCase):
         rip = self.d.rip
         self.assertEqual (rip, value)
 
+    def test_detach(self):
+        pid = self.d.pid
+        b = self.d.breakpoint(0x10e2)
+        self.d.cont()
+        self.d.del_bp(b)
+        self.d.detach()
+        self.d.attach(pid)
+        self.d.step() # Catch the sigstop from the attach
+        self.assertEqual(self.d.stop_status, 0x137f)
+        self.assertEqual(self.d.rip, self.d.bases['main'] + 0x10e2)
+        self.d.cont(blocking=False)
+        # Be sure that we are running
+        self.assertFalse(self.d.threads[self.d.pid]._test_execution())
+        self.d.detach()
+        self.d.attach(pid)
+        self.assertNotEqual(self.d.rip, self.d.bases['main'] + 0x10e2)
+        self.d.cont(blocking=False)
+        self.assertFalse(self.d.threads[self.d.pid]._test_execution())
+        self.d.detach()
+
 class Debugger_read_mem(unittest.TestCase):
     def setUp(self):
         self.d = Debugger(multithread=False)

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,7 +5,7 @@ from pwn import process
 import time
 class Debugger_read(unittest.TestCase):
     def setUp(self):
-        self.d = Debugger()
+        self.d = Debugger(multithread=False)
         self.d.run("./read_test", sleep=0.1)
         self.mem_addr = 0x1aabbcc1000
 
@@ -59,7 +59,7 @@ class Debugger_read(unittest.TestCase):
 
 class Debugger_read_mem(unittest.TestCase):
     def setUp(self):
-        self.d = Debugger()
+        self.d = Debugger(multithread=False)
         self.d.run("./read_test_mem")
         self.mem_addr = 0x1aabbcc1000
 
@@ -95,7 +95,7 @@ class Debugger_read_mem(unittest.TestCase):
 # This is bugged I do not understand yet.
 class Debugger_write(unittest.TestCase):
     def setUp(self):
-        self.d = Debugger()
+        self.d = Debugger(multithread=False)
         self.p = process("./write_test")
         self.d.attach(self.p.pid)
 
@@ -158,7 +158,7 @@ class Debugger_write(unittest.TestCase):
 
 class Debugger_cf(unittest.TestCase):
     def setUp(self):
-        self.d = Debugger()
+        self.d = Debugger(multithread=False)
         self.binary = "./read_test"
 
     def tearDown(self):


### PR DESCRIPTION
Parte principale:
- Mi assicuro che il processo sia interrotto quando viene chiamato `detach() per evitare che possa fallire
- Chiudo correttamente il thread che chiama waitpid per evitare che faccia problemi se crei un nuovo debugger per tracciare lo stesso processo
- Permetto di usare `Debugger(multithread=False)` in modo da chiamare `waitpid(self.pid)` invece di `waitpid(-1)` così puoi usare diversi debugger senza che si rubino i segnali a vicenda.

Modifiche minori:
- L'utente può importare PtraceFail e DebugFail per gestire queste eccezioni
- Avevo fatto una cazzata non gestendo le eccezioni di ptrace quindi in caso di problemi morivano i thread senza dire nulla. Ora dovrebbe fare raise nel thread principale.
- Ogni thread aspetta di essersi fermato quando chiami `step()` così siamo sicuri di non perderci nulla.